### PR TITLE
Add support for extracting sounds

### DIFF
--- a/FileReader/SilFileReader.cs
+++ b/FileReader/SilFileReader.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace S4GFX.FileReader
+{
+	class SilFileReader : GilFileReader
+	{   // Sil File is basically just handled like a GilFile. ID 0 is NO_SOUND
+		public SilFileReader(BinaryReader reader) : base(reader) {}
+
+		public int GetSoundCount()
+		{
+			return base.GetImageCount();
+		}
+
+		public Int32 GetSoundOffset(int index)
+		{
+			return GetImageOffset(index);
+		}
+	}
+}

--- a/FileReader/SndFileReader.cs
+++ b/FileReader/SndFileReader.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using S4GFX.GFX;
+
+namespace S4GFX.FileReader
+{
+	class SndFileReader : FileReaderBase
+	{
+		byte[][] sounds; // first index is sound ID, second index is byte of sound file (type is wave)
+
+		SilFileReader offsetTable;
+
+		public int GetSoundCount() {
+			return sounds != null ? sounds.Length : 0;
+		}
+
+		public byte[] GetSound(int index) {
+			// note that sound with ID 0 is NO_SOUND
+			if ((index <= 0) || (index >= sounds.Length)) {
+				return null;
+			}
+
+			return sounds[index];
+		}
+
+		public void ChangeSoundData(int index, byte[] newData) {
+			throw new NotImplementedException("sorry, this has not yet been implemented");
+		}
+		
+		public SndFileReader(BinaryReader reader,
+			SilFileReader offsetTable) {
+
+			this.offsetTable = offsetTable;
+
+			ReadResource(reader);
+
+			reader.BaseStream.Seek(0, SeekOrigin.Begin);
+			Byte[] buffer = reader.ReadBytes((int)reader.BaseStream.Length);
+
+			reader.BaseStream.Seek(HeaderSize, SeekOrigin.Begin);
+
+			int count = offsetTable.GetSoundCount();
+			sounds = new byte[count][];
+
+			sounds[0] = new byte[0]; // sound ID 0 is NO_SOUND
+
+			for (int i = 1; i < count; i++) {
+				int gfxOffset = offsetTable.GetSoundOffset(i);
+
+				int jobIndex = i;
+
+				sounds[i] = ReadSound(reader, gfxOffset, buffer);
+			}
+		}
+
+		byte[] ReadSound(BinaryReader reader, int offset, Byte[] buffer) {
+			reader.BaseStream.Seek(offset, SeekOrigin.Begin);
+
+			int sndHeadType = reader.ReadInt32(); // always 1 ?
+			int sndSize = reader.ReadInt32();
+
+			return reader.ReadBytes(sndSize);
+		}
+	}
+}

--- a/S4GFX.csproj
+++ b/S4GFX.csproj
@@ -52,6 +52,8 @@
     <Compile Include="FileReader\JilFileReader.cs" />
     <Compile Include="FileReader\PaletteCollection.cs" />
     <Compile Include="FileReader\PilFileReader.cs" />
+    <Compile Include="FileReader\SilFileReader.cs" />
+    <Compile Include="FileReader\SndFileReader.cs" />
     <Compile Include="GFX\DirectBitmap.cs" />
     <Compile Include="GFX\GfxImage.cs" />
     <Compile Include="GFX\IGfxImage.cs" />


### PR DESCRIPTION
This will add support for extracting the sound archive (0.snd) of the game. Therefore, it adds the corresponding SndFileReader and SilFileReader. 

This feature is disabled by default. Add the `--snd` argument to the command line to enable it.

The sounds are just a bunch of wav files. I tried to implement it as close as possible to the original code base.

see #3.